### PR TITLE
4r (Sp): add missing "tu" (at ixim; dí tu maís)

### DIFF
--- a/xom-all-flat-mod-pnums.xml
+++ b/xom-all-flat-mod-pnums.xml
@@ -6250,7 +6250,7 @@ perhaps priests not deities?</note>
 <lb n="26"/>formadores, y sí es este es <choice><abbr>q’</abbr><expan instant="false">que</expan></choice>se ha de sus<pc> –</pc>
  <note resp="editor">what to do with formadores </note>
 <lb n="27"/>tentar, y alímentar, <choice><abbr>q<hi rend="superscript">o</hi></abbr><expan instant="false">cuando</expan></choice> se siembre, y acba<pc> –</pc>
-<lb n="28"/>re, dí maís, tu ꜩíte, tu sol, tu forma<pc> –</pc>
+<lb n="28"/>re, dí tu maís, tu ꜩíte, tu sol, tu forma<pc> –</pc>
 <lb n="29"/>dura llamad, y segued le dixo al maís,
 <lb n="30"/>y al ꜩíte, al sol, y ála formadura. y tu
 <lb n="31"/><rs ana="UKUX_KAJ">corazon de el zielo</rs> tened verguenza, no afren<pc> –</pc>


### PR DESCRIPTION
I was writing an annotation for Ximénez's use of "q,íte" after consistently using "ꜩíte" in 4r. Noticed that the K'iche' column correctly transcribed "at ixim, at ꜩíte" but the Spanish was missing the "tu" (at). This is my smallest commit ever and most words used to describe what I did.