### PR TITLE
metadata

### DIFF
--- a/xom-all-flat-mod-pnums.xml
+++ b/xom-all-flat-mod-pnums.xml
@@ -8,10 +8,15 @@
 <title>Arte de las tres lenguas kakchiquel, quiché y ꜩutuhil, 
 v.2 Popol vuh; and Escolios a la historia de el origen de los Indios.</title>
 <author>Ximénez, Francisco</author>
+<author>Nim Chokoj k'ut chuwach Kaweqib' (gran maestro de la palabra ante los Kaweq)</author>
+<author>chuwach Nija'ib', ukab' k'u ri' (gran maestro de la palabra ante los Nija'ib era el segundo)</author>
+<author>Nim Chokoj Ajaw chuwach Ajaw K'iche', rox Nim Chokoj (gran maestro de la palabra era el tercer Señor ante los Ajaw K'iche)</author>
 </titleStmt>
 <publicationStmt>
 <publisher>The Newberry Library</publisher>
+<publisher>le winaq</publisher>
 <pubPlace>Chicago, Illinois, USA</pubPlace>
+<pubPlace>Iximulew</pubPlace>
 </publicationStmt>
 <sourceDesc>
 <p>An encoded transciption of the Newberry Library's VAULT Ayer MS 1515, volume 2, Folio , Side .


### PR DESCRIPTION
Read María Montenegro, "Subverting the universality of metadata standards: The TK labels as a tool to promote Indigenous data sovereignty," Journal of Documentation, 75.4 (2017), pp.731-749, https://doi.org/10.1108/JD-08-2018-0124. First try at metadata that acknowledges K'iche' authors and publication context.